### PR TITLE
feat: initial defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ Collection of [Renovate config presets](https://docs.renovatebot.com/config-pres
 
     ```json
     {
-      "extends": ["github>reside-eng/renovate-config", ":assignee(<TEAM>)"]
+      "extends": [
+        "github>reside-eng/renovate-config",
+        ":assignee(<TEAM>)"
+      ]
     }
     ```
 
@@ -21,3 +24,29 @@ Collection of [Renovate config presets](https://docs.renovatebot.com/config-pres
     package.json
     yarn.lock
     ```
+
+## Config Template Options
+
+### Default
+
+* Labels NPM and Github Actions PRs
+* Requires 3 days of stability for npm dependencies (not dev) - during this time npm packages can be unpublished
+* Auto-merges non-major NPM dev dependencies off business hours - prevents overlap and need for update with developer's PRs during the day
+* Auto-merges non-major Github Actions dependencies
+
+## Service
+
+For backend services
+
+### Library
+
+For npm libraries
+
+* Groups minor/patch npm dependencies into 1 weekly release monday morning (to prevent release for every dependency update)
+
+### Action
+
+For custom Github Action
+
+* Extends Library
+* Builds bundle before commit (since dist is part of git tracking)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ NOTE: all non-default templates are used by name within `extends`. For example, 
 * Sets commit type and scope for Github Actions dependency updates
 * Sets timezone to `America/Los_Angeles` to match Side's Office for all schedules
 * Maintains lock file weekly on Monday morning
+* Groups config and `@types/config` updates
 
 ### Service
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ NOTE: all non-default templates are used by name within `extends`. For example, 
 * Sets timezone to `America/Los_Angeles` to match Side's Office for all schedules
 * Maintains lock file weekly on Monday morning
 * Groups common dependencies including:
+  * All packages in [Side lint-config](https://github.com/reside-eng/lint-config)
   * `config` and `@types/config` updates
   * `@testing-library` monorepo
 * Skips Faker updates since it is no longer supported

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Collection of [Renovate config presets](https://docs.renovatebot.com/config-pres
     {
       "extends": [
         "github>reside-eng/renovate-config",
-        ":assignee(<TEAM>)"
+        ":reviewer(<TEAM>)"
       ]
     }
     ```

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ NOTE: all non-default templates are used by name within `extends`. For example, 
 * Sets timezone to `America/Los_Angeles` to match Side's Office for all schedules
 * Maintains lock file weekly on Monday morning
 
-## Service
+### Service
 
-For backend services
+For backend services and UIs
 
 * Auto-merges non-major NPM dev dependencies off business hours - prevents overlap and need for update with developer's PRs during the day
 * Auto-merges patch NPM dependencies off business hours - prevents overlap and need for update with developer's PRs during the day

--- a/README.md
+++ b/README.md
@@ -40,25 +40,28 @@ NOTE: all non-default templates are used by name within `extends`. For example, 
 ### Default
 
 * Labels NPM and Github Actions PRs
-* Requires 3 days of stability for npm dependencies (not dev) - during this time npm packages can be unpublished
+* Requires 3 days of stability for npm dependencies (not dev) which are not managed by Side Inc. - during this window npm packages can be un-published which can break builds
 * Sets commit type and scope for Github Actions dependency updates
 * Sets timezone to `America/Los_Angeles` to match Side's Office for all schedules
 * Maintains lock file weekly on Monday morning
-* Groups config and `@types/config` updates
+* Groups common dependencies including:
+  * `config` and `@types/config` updates
+  * `@testing-library` monorepo
+* Skips Faker updates since it is no longer supported
 
 ### Service
 
-For backend services and UIs
+For applications that are using continuous delivery including backend services and UIs
 
 * Auto-merges non-major NPM dev dependencies off business hours - prevents overlap and need for update with developer's PRs during the day
-* Auto-merges patch NPM dependencies off business hours - prevents overlap and need for update with developer's PRs during the day
+* Auto-merges patch NPM dependencies on weekday mornings before the day starts (after 5am before 8am) - Engineers will be around if bugs arise, but still prevents overlap with daytime PRs
 * Auto-merges non-major Github Actions off business hours - prevents overlap and need for update with developer's PRs during the day
 
 ### Library
 
 For npm libraries
 
-* Groups minor/patch npm dependencies into 1 weekly release monday morning (to prevent release for every dependency update)
+* Groups minor/patch npm dependencies into 1 weekly release monday morning - to prevent release for every dependency update
 * Auto-merges non-major dev dependencies
 * Auto-merges non-major Github Actions
 

--- a/README.md
+++ b/README.md
@@ -25,24 +25,41 @@ Collection of [Renovate config presets](https://docs.renovatebot.com/config-pres
     yarn.lock
     ```
 
-## Config Template Options
+## Config Templates
+
+NOTE: all non-default templates are used by name within `extends`. For example, for the template named "service" you would use the following:
+
+    ```json
+    {
+      "extends": [
+        "github>reside-eng/renovate-config:service"
+      ]
+    }
+    ```
 
 ### Default
 
 * Labels NPM and Github Actions PRs
 * Requires 3 days of stability for npm dependencies (not dev) - during this time npm packages can be unpublished
-* Auto-merges non-major NPM dev dependencies off business hours - prevents overlap and need for update with developer's PRs during the day
-* Auto-merges non-major Github Actions dependencies
+* Sets commit type and scope for Github Actions dependency updates
+* Sets timezone to `America/Los_Angeles` to match Side's Office for all schedules
+* Maintains lock file weekly on Monday morning
 
 ## Service
 
 For backend services
+
+* Auto-merges non-major NPM dev dependencies off business hours - prevents overlap and need for update with developer's PRs during the day
+* Auto-merges patch NPM dependencies off business hours - prevents overlap and need for update with developer's PRs during the day
+* Auto-merges non-major Github Actions off business hours - prevents overlap and need for update with developer's PRs during the day
 
 ### Library
 
 For npm libraries
 
 * Groups minor/patch npm dependencies into 1 weekly release monday morning (to prevent release for every dependency update)
+* Auto-merges non-major dev dependencies
+* Auto-merges non-major Github Actions
 
 ### Action
 

--- a/action.json
+++ b/action.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>reside-eng/renovate-config:library"
+  ],
+  "allowedPostUpgradeCommands": ["^yarn build"],
+  "postUpgradeTasks": {
+    "commands": ["yarn build"],
+    "fileFilters": ["yarn.lock", "dist/**"],
+    "executionMode": "update"
+  }
+}

--- a/default.json
+++ b/default.json
@@ -6,26 +6,27 @@
   "timezone": "America/Los_Angeles",
   "prHourlyLimit": 0,
   "lockFileMaintenance": {
-    "schedule": [
-      "before 9am on monday"
+    "enabled": true,
+    "extends": [
+      "schedule:weekly"
     ]
   },
   "packageRules": [
     {
       "description": "Label NPM dev dependencies",
       "matchDatasources": ["npm"],
-      "matchDepTypes": "devDependencies",
+      "matchDepTypes": ["devDependencies"],
       "labels": ["devDependencies"]
     },
     {
       "description": "Label NPM dependencies",
       "matchDatasources": ["npm"],
-      "matchDepTypes": "dependencies",
+      "matchDepTypes": ["dependencies"],
       "labels": ["dependencies"]
     },
     {
       "description": "Configure Github Actions dependencies (labels, commit format)",
-      "matchDepTypes": "action",
+      "matchDepTypes": ["action"],
       "labels": ["actions"],
       "semanticCommitType": "chore",
       "semanticCommitScope": "ci-deps"
@@ -33,7 +34,7 @@
     {
       "description": "Require stability of NPM dependencies which are not managed by Side Inc. (since they can be unpublished)",
       "matchDatasources": ["npm"],
-      "matchDepTypes": "dependencies",
+      "matchDepTypes": ["dependencies"],
       "excludePackagePatterns": ["^@side"],
       "stabilityDays": 3
     }

--- a/default.json
+++ b/default.json
@@ -46,13 +46,14 @@
       "enabled": false
     },
     {
+      "description": "node-config library and types",
       "matchPackageNames": ["config", "@types/config"],
       "groupName": "Node config and types",
       "groupSlug": "node-config"
     },
     {
       "description": "Test Library Monorepo group",
-      "matchPackagePatters": ["^@testing-library"],
+      "matchPackagePrefixes": ["@testing-library/"],
       "groupName": "Testing Library Monorepo",
       "groupSlug": "testing-library"
     }

--- a/default.json
+++ b/default.json
@@ -39,6 +39,22 @@
       "matchDepTypes": ["dependencies"],
       "excludePackagePatterns": ["^@side"],
       "stabilityDays": 3
+    },
+    {
+      "description": "Skip faker updates (since it is no longer supported)",
+      "matchPackageNames": ["faker", "@types/faker"],
+      "enabled": false
+    },
+    {
+      "matchPackageNames": ["config", "@types/config"],
+      "groupName": "Node config and types",
+      "groupSlug": "node-config"
+    },
+    {
+      "description": "Test Library Monorepo group",
+      "matchPackagePatters": ["^@testing-library"],
+      "groupName": "Testing Library Monorepo",
+      "groupSlug": "testing-library"
     }
   ]
 }

--- a/default.json
+++ b/default.json
@@ -3,8 +3,8 @@
   "extends": [
     "config:base"
   ],
+  "timezone": "America/Los_Angeles",
   "prHourlyLimit": 0,
-  "masterIssue": true,
   "lockFileMaintenance": {
     "schedule": [
       "before 9am on monday"
@@ -12,11 +12,30 @@
   },
   "packageRules": [
     {
-      "description": "Automerge non-major updates",
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true,
-      "automergeType": "pr",
-      "automergeStrategy": "squash"
+      "description": "Label NPM dev dependencies",
+      "matchDatasources": ["npm"],
+      "matchDepTypes": "devDependencies",
+      "labels": ["devDependencies"]
+    },
+    {
+      "description": "Label NPM dependencies",
+      "matchDatasources": ["npm"],
+      "matchDepTypes": "dependencies",
+      "labels": ["dependencies"]
+    },
+    {
+      "description": "Configure Github Actions dependencies (labels, commit format)",
+      "matchDepTypes": "action",
+      "labels": ["actions"],
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "ci-deps"
+    },
+    {
+      "description": "Require stability of NPM dependencies which are not managed by Side Inc. (since they can be unpublished)",
+      "matchDatasources": ["npm"],
+      "matchDepTypes": "dependencies",
+      "excludePackagePatterns": ["^@side"],
+      "stabilityDays": 3
     }
   ]
 }

--- a/default.json
+++ b/default.json
@@ -1,9 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
-    "group:typescript-eslintMonorepo",
-    "group:commitlintMonorepo"
+    "config:base"
   ],
   "timezone": "America/Los_Angeles",
   "prHourlyLimit": 0,
@@ -41,6 +39,12 @@
       "stabilityDays": 3
     },
     {
+      "description": "Group Side Inc. lint configs",
+      "matchSourceUrlPrefixes": ["https://github.com/reside-eng/lint-config"],
+      "groupName": "Side lint config",
+      "groupSlug": "side-lint-config"
+    },
+    {
       "description": "Skip faker updates (since it is no longer supported)",
       "matchPackageNames": ["faker", "@types/faker"],
       "enabled": false
@@ -50,12 +54,6 @@
       "matchPackageNames": ["config", "@types/config"],
       "groupName": "Node config and types",
       "groupSlug": "node-config"
-    },
-    {
-      "description": "Test Library Monorepo group",
-      "matchPackagePrefixes": ["@testing-library/"],
-      "groupName": "Testing Library Monorepo",
-      "groupSlug": "testing-library"
     }
   ]
 }

--- a/default.json
+++ b/default.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:base",
+    "group:typescript-eslintMonorepo",
+    "group:commitlintMonorepo"
   ],
   "timezone": "America/Los_Angeles",
   "prHourlyLimit": 0,

--- a/library.json
+++ b/library.json
@@ -35,11 +35,6 @@
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash"
-    },
-    {
-      "matchPackageNames": ["config", "@types/config"],
-      "groupName": "Node config and types",
-      "groupSlug": "node-config"
     }
   ]
 }

--- a/library.json
+++ b/library.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>reside-eng/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "description": "Automerge non-major npm dev dependencies",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchDatasources": ["npm"],
+      "matchDepTypes": "devDependencies",
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash"
+    },
+    {
+      "description": "Weekly npm dependencies maintenance (grouped minor + patch updates)",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchDatasources": ["npm"],
+      "matchDepTypes": "dependencies",
+      "schedule": [
+        "before 10pm monday"
+      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash",
+      "groupName": "Weekly npm maintenance release"
+    },
+    {
+      "description": "Automerge non-major Github Actions dependencies",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchDepTypes": "action",
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash"
+    }
+  ]
+}

--- a/library.json
+++ b/library.json
@@ -8,7 +8,7 @@
       "description": "Automerge non-major npm dev dependencies",
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "matchDatasources": ["npm"],
-      "matchDepTypes": "devDependencies",
+      "matchDepTypes": ["devDependencies"],
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash"
@@ -17,7 +17,7 @@
       "description": "Weekly npm dependencies maintenance (grouped minor + patch updates)",
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "matchDatasources": ["npm"],
-      "matchDepTypes": "dependencies",
+      "matchDepTypes": ["dependencies"],
       "schedule": [
         "before 10pm monday"
       ],
@@ -29,7 +29,7 @@
     {
       "description": "Automerge non-major Github Actions dependencies",
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "matchDepTypes": "action",
+      "matchDepTypes": ["action"],
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash"

--- a/library.json
+++ b/library.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>reside-eng/renovate-config"
+    "github>reside-eng/renovate-config",
+    ":pinOnlyDevDependencies"
   ],
   "packageRules": [
     {
@@ -19,12 +20,13 @@
       "matchDatasources": ["npm"],
       "matchDepTypes": ["dependencies"],
       "schedule": [
-        "before 10pm monday"
+        "before 8am monday"
       ],
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash",
-      "groupName": "Weekly npm maintenance release"
+      "groupName": "Weekly npm maintenance release",
+      "groupSlug": "weekly-npm-maintenance"
     },
     {
       "description": "Automerge non-major Github Actions dependencies",
@@ -33,6 +35,11 @@
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash"
+    },
+    {
+      "matchPackageNames": ["config", "@types/config"],
+      "groupName": "Node config and types",
+      "groupSlug": "node-config"
     }
   ]
 }

--- a/service.json
+++ b/service.json
@@ -8,7 +8,7 @@
       "description": "Automerge non-major npm dev dependencies off business hours",
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "matchDatasources": ["npm"],
-      "matchDepTypes": "devDependencies",
+      "matchDepTypes": ["devDependencies"],
       "schedule": [
         "after 10pm and before 5am every weekday",
         "every weekend"
@@ -21,9 +21,9 @@
       "description": "Automerge patch npm dependencies off business hours",
       "matchUpdateTypes": ["patch", "pin", "digest"],
       "matchDatasources": ["npm"],
-      "matchDepTypes": "dependencies",
+      "matchDepTypes": ["dependencies"],
       "schedule": [
-        "after 10pm and before 5am every weekday",
+        "after 8am and before 5am every weekday",
         "every weekend"
       ],
       "automerge": true,
@@ -33,7 +33,7 @@
     {
       "description": "Automerge non-major Github Actions dependencies off business hours",
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "matchDepTypes": "action",
+      "matchDepTypes": ["action"],
       "schedule": [
         "after 10pm and before 5am every weekday",
         "every weekend"

--- a/service.json
+++ b/service.json
@@ -1,7 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>reside-eng/renovate-config"
+    "github>reside-eng/renovate-config",
+    "packages:react",
+    "group:graphql-toolsMonorepo",
+    "group:material-uiMonorepo",
+    "group:storybookMonorepo",
+    "group:nextjsMonorepo"
   ],
   "packageRules": [
     {
@@ -18,13 +23,12 @@
       "automergeStrategy": "squash"
     },
     {
-      "description": "Automerge patch npm dependencies off business hours",
+      "description": "Automerge patch npm dependencies off business hours on weeknights",
       "matchUpdateTypes": ["patch", "pin", "digest"],
       "matchDatasources": ["npm"],
       "matchDepTypes": ["dependencies"],
       "schedule": [
-        "after 8am and before 5am every weekday",
-        "every weekend"
+        "after 10pm and before 8am every weekday"
       ],
       "automerge": true,
       "automergeType": "pr",

--- a/service.json
+++ b/service.json
@@ -6,7 +6,8 @@
     "group:graphql-toolsMonorepo",
     "group:material-uiMonorepo",
     "group:storybookMonorepo",
-    "group:nextjsMonorepo"
+    "group:nextjsMonorepo",
+    "group:emotionMonorepo"
   ],
   "packageRules": [
     {
@@ -23,12 +24,12 @@
       "automergeStrategy": "squash"
     },
     {
-      "description": "Automerge patch npm dependencies off business hours on weeknights",
+      "description": "Automerge patch npm dependencies off business hours on weekday mornings",
       "matchUpdateTypes": ["patch", "pin", "digest"],
       "matchDatasources": ["npm"],
       "matchDepTypes": ["dependencies"],
       "schedule": [
-        "after 10pm and before 8am every weekday"
+        "after 6am and before 8am every weekday"
       ],
       "automerge": true,
       "automergeType": "pr",

--- a/service.json
+++ b/service.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>reside-eng/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "description": "Automerge non-major npm dev dependencies off business hours",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchDatasources": ["npm"],
+      "matchDepTypes": "devDependencies",
+      "schedule": [
+        "after 10pm and before 5am every weekday",
+        "every weekend"
+      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash"
+    },
+    {
+      "description": "Automerge patch npm dependencies off business hours",
+      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "matchDatasources": ["npm"],
+      "matchDepTypes": "dependencies",
+      "schedule": [
+        "after 10pm and before 5am every weekday",
+        "every weekend"
+      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash"
+    },
+    {
+      "description": "Automerge non-major Github Actions dependencies off business hours",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchDepTypes": "action",
+      "schedule": [
+        "after 10pm and before 5am every weekday",
+        "every weekend"
+      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash"
+    }
+  ]
+}

--- a/service.json
+++ b/service.json
@@ -29,7 +29,7 @@
       "matchDatasources": ["npm"],
       "matchDepTypes": ["dependencies"],
       "schedule": [
-        "after 6am and before 8am every weekday"
+        "after 5am and before 8am every weekday"
       ],
       "automerge": true,
       "automergeType": "pr",


### PR DESCRIPTION
Setup the following functionality for each of the templates:

### Default

* Labels NPM and Github Actions PRs
* Requires 3 days of stability for npm dependencies (not dev) - during this time npm packages can be unpublished
* Sets commit type and scope for Github Actions dependency updates
* Sets timezone to `America/Los_Angeles` to match Side's Office for all schedules
* Maintains lock file weekly on Monday morning

### Service

For backend services and UIs

* Auto-merges non-major NPM dev dependencies off business hours - prevents overlap and need for update with developer's PRs during the day
* Auto-merges patch NPM dependencies off business hours - prevents overlap and need for update with developer's PRs during the day
* Auto-merges non-major Github Actions off business hours - prevents overlap and need for update with developer's PRs during the day

### Library

For npm libraries

* Groups minor/patch npm dependencies into 1 weekly release monday morning (to prevent release for every dependency update)
* Auto-merges non-major dev dependencies
* Auto-merges non-major Github Actions

### Action

For custom Github Action

* Extends Library
* Builds bundle before commit (since dist is part of git tracking)