### PR TITLE
fix: group redis with associated types

### DIFF
--- a/service.json
+++ b/service.json
@@ -42,6 +42,12 @@
       "automergeStrategy": "squash"
     },
     {
+      "description": "Group redis npm dependency with associated types",
+      "matchPackageNames": ["redis", "@types/redis"],
+      "groupName": "Redis with types",
+      "groupSlug": "redis"
+    },
+    {
       "description": "Automerge non-major Github Actions dependencies off business hours",
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "matchDepTypes": ["action"],


### PR DESCRIPTION
Grouping of redis with it's types - especially important

Worth note: in v4 of redis the types are included with the library itself (@types/redis shows placeholder message)

