### PR TITLE
fix: include pdfjs-dist in trusted packages

### DIFF
--- a/default.json
+++ b/default.json
@@ -87,6 +87,7 @@
         "recoil",
         "yup",
         "launchdarkly-react-client-sdk",
+        "pdfjs-dist",
         "pino"
       ],
       "prCreation": "not-pending",


### PR DESCRIPTION
pdfjs-dist is published by Mozilla so it is being added to the trused list