### PR TITLE
fix: lock dd-trace to 2.6.0 [PLAT-2236]

### DIFF
--- a/default.json
+++ b/default.json
@@ -5,6 +5,7 @@
   "ignorePresets": [":prHourlyLimit2"],
   "timezone": "America/Los_Angeles",
   "prHourlyLimit": 0,
+  "platformAutomerge": true,
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,

--- a/default.json
+++ b/default.json
@@ -5,7 +5,6 @@
   "ignorePresets": [":prHourlyLimit2"],
   "timezone": "America/Los_Angeles",
   "prHourlyLimit": 0,
-  "platformAutomerge": true,
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,

--- a/service.json
+++ b/service.json
@@ -54,7 +54,7 @@
       "groupSlug": "minor-npm-deps"
     },
     {
-      "description": "Lock version of dd-trace due to memory leak",
+      "description": "Lock version of dd-trace due to memory leak [PLAT-2236]",
       "matchPackageNames": ["dd-trace"],
       "matchManagers": ["npm"],
       "allowedVersions": "2.6.0"

--- a/service.json
+++ b/service.json
@@ -9,6 +9,7 @@
     "group:nextjsMonorepo",
     "group:emotionMonorepo"
   ],
+  "platformAutomerge": true,
   "packageRules": [
     {
       "description": "Automerge non-major NPM dev dependencies off business hours",
@@ -51,6 +52,12 @@
       "schedule": ["before 8am on Monday"],
       "groupName": "Minor npm deps",
       "groupSlug": "minor-npm-deps"
+    },
+    {
+      "description": "Lock version of dd-trace due to memory leak",
+      "matchPackageNames": ["dd-trace"],
+      "matchManagers": ["npm"],
+      "allowedVersions": "2.6.0"
     }
   ]
 }

--- a/service.json
+++ b/service.json
@@ -54,7 +54,7 @@
       "groupSlug": "minor-npm-deps"
     },
     {
-      "description": "Lock version of dd-trace due to memory leak [PLAT-2236]",
+      "description": "Lock version of dd-trace due to memory leak in v2.7.1 [PLAT-2236]",
       "matchPackageNames": ["dd-trace"],
       "matchManagers": ["npm"],
       "allowedVersions": "2.6.0"


### PR DESCRIPTION
Locks dd-trace to v2.6.0 due to a memory leak in v2.7.1