### PR TITLE
feat: separate actions-ci labeling to a preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ For custom Github Action
 - Extends Library
 - Builds bundle before commit (since dist is part of git tracking)
 
+### Actions CI
+
+For labeling Github Actions with correct semantic release type and scope as well as apply labels. This was separated into it's own preset so that it can be skipped for repos which may not want this default such as [workflow-templates](https://github.com/reside-eng/workflow-templates) (which has templates in that folder which are not "ci" for that repo)
+
 ### Take Home Assignment
 
 For take home assignment repos

--- a/actions-ci.json
+++ b/actions-ci.json
@@ -1,0 +1,11 @@
+{
+  "packageRules": [
+    {
+      "description": "Configure Github Actions dependencies (labels, commit format)",
+      "matchDepTypes": ["action"],
+      "labels": ["github_actions", "ci"],
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "ci-deps"
+    }
+  ]
+}

--- a/default.json
+++ b/default.json
@@ -1,7 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "onboardingPrTitle": "chore(deps): configure renovate",
-  "extends": ["config:base", "github>reside-eng/renovate-config:private-npm"],
+  "extends": [
+    "config:base",
+    "github>reside-eng/renovate-config:private-npm",
+    "github>reside-eng/renovate-config:actions-ci"
+  ],
   "ignorePresets": [":prHourlyLimit2"],
   "timezone": "America/Los_Angeles",
   "prHourlyLimit": 0,

--- a/default.json
+++ b/default.json
@@ -29,13 +29,6 @@
       "labels": ["dependencies"]
     },
     {
-      "description": "Configure Github Actions dependencies (labels, commit format)",
-      "matchDepTypes": ["action"],
-      "labels": ["github_actions", "ci"],
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "ci-deps"
-    },
-    {
       "matchDatasources": ["docker"],
       "labels": ["docker-deps"]
     },


### PR DESCRIPTION
Make actions labeling it's own preset so it can be ignored in repos like workflow-templates (which has yaml files in .github/workflows folder which are not CI for that repo)