### PR TITLE
fix: allow dd-trace to update to latest

### DIFF
--- a/service.json
+++ b/service.json
@@ -54,12 +54,6 @@
       "groupSlug": "minor-npm-deps"
     },
     {
-      "description": "Lock version of dd-trace due to memory leak in v2.7.1 [PLAT-2236]",
-      "matchPackageNames": ["dd-trace"],
-      "matchManagers": ["npm"],
-      "allowedVersions": "2.6.0"
-    },
-    {
       "description": "Group Fastify and Fastify scoped packages",
       "matchPackageNames": ["fastify", "fastify-plugin"],
       "matchPackagePrefixes": ["@fastify/"],


### PR DESCRIPTION
It appears the memory leak issue was resolved in latest