### PR TITLE
feat: group `@mui/x-*` packages

### DIFF
--- a/service.json
+++ b/service.json
@@ -59,6 +59,12 @@
       "matchPackagePrefixes": ["@fastify/"],
       "groupName": "Fastify packages",
       "groupSlug": "fastify-packages"
+    },
+    {
+      "description": "Group @mui/x-* packages",
+      "matchPackagePatterns": ["^@mui/x-"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "MUI X"
     }
   ]
 }


### PR DESCRIPTION
## Changes

Added Renovate group for `@mui/x-*` library updates (patch and minor).

## Notes for Reviewers

MUI X libraries seem to break somewhat frequently and will hold back regular minor updates from other libraries. This PR updates our Renovate config to isolate patch and minor updates for those libraries.
