### PR TITLE
fix(schedule): account for eastern time

### DIFF
--- a/library.json
+++ b/library.json
@@ -23,7 +23,7 @@
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "matchDatasources": ["npm"],
       "matchDepTypes": ["dependencies"],
-      "schedule": ["before 8am on Monday"],
+      "schedule": ["before 5am on Monday"],
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash",

--- a/service.json
+++ b/service.json
@@ -37,7 +37,7 @@
       "matchUpdateTypes": ["patch", "pin", "digest"],
       "matchDatasources": ["npm"],
       "matchDepTypes": ["dependencies"],
-      "schedule": ["after 5am and before 8am every weekday"],
+      "schedule": ["after 2am and before 5am every weekday"],
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash",
@@ -49,7 +49,7 @@
       "matchUpdateTypes": ["minor"],
       "matchDatasources": ["npm"],
       "matchDepTypes": ["dependencies"],
-      "schedule": ["before 8am on Monday"],
+      "schedule": ["before 5am on Monday"],
       "groupName": "Minor npm deps",
       "groupSlug": "minor-npm-deps"
     },


### PR DESCRIPTION
8 am Pacific gets a little late for folks in other time zones, so I've set the three rules that weren't consistent with the 5 am pattern to match. Here are some examples of rules that already had the 5 am pattern ([1](https://github.com/reside-eng/renovate-config/blob/main/service.json#L28), [2](https://github.com/reside-eng/renovate-config/blob/main/service.json#L19))