### PR TITLE
fix: add support for yarn berry config

### DIFF
--- a/private-npm.json
+++ b/private-npm.json
@@ -1,5 +1,14 @@
 {
   "encrypted": {
     "npmToken": "wcFMA/xDdHCJBTolARAAg0+G3xnvrn++I3k2LIjw/lREot4qnukO3LnPz8EPktc+8XO071PgkBP5RhCEfn7xnhEUlJl4UggrjMktcG6/Q2zjxAKCnWbaUq6rZbxkVLN/LFK98x9phLkXkNlXlIlvwwuCrWt1bMl5NRPa/kb2qEBjyVyjaTHjUpZ5LpsTfeee5PjQ8xP2eA1cN5LoEeqG1Gow7Lt0ejC01yc1ZQzAmbZ+Lmmrl08bLHYZOsj2/qAp/uCsz9NhwoFkZaEFrSZqaEHiplnqyHQbEQd1gsd4826qRsoEZIPaXV9s08JDfyrOdbnMsQ5cZHDoevD/IB83C/9YghCKhbMp+OsZpT36daBBmYr/NEPFvpYs9vpJcj8CzyFSR46nErtjA4bjj8btLmHuWcWWZX3uwISsMjCfP9++MzaiG9rPvZ70aYcdi5dsmahPrA4PsGPZcmJcpqOYASXodrDcSVTlGUGrFVWlbCpoWorZ8Fr5x+8I07m6RXkxY34QyrAziHhkZB3kpupd/JafzgPdFRgxyfKqgdz01PzNF9QRKWiAPQ+sNnWvZNgd38lVvN69y/GfpM2UYo/dm51D40r/yGPEuAWd76rvXN9uvpBhCSC9RwmsagVONOAauePZvmRxw8NCiy5z4ljQtgAzWrpuv0QfCyVzCf5i5gh1ZquRD8Q19T/iqFZkbTzSeQGcCKl3zunRi5hDT2GqdV1Dv1fr13rXieTuAnANyyra3LkHeUgg9Yyx5KOI8cUn/k74juVzogZAbq/VrjQkRKG+A83oi1FRHi0Lo+N6j2XzvRT3WJuPRdAIvrIp9ec7o8D64XjpmbbMaLT2SKPWalra4mf2wkNYTPY"
-  }
+  },
+  "hostRules": [
+    {
+      "matchHost": "registry.npmjs.org",
+      "hostType": "npm",
+      "encrypted": {
+        "token": "wcFMA/xDdHCJBTolARAAg0+G3xnvrn++I3k2LIjw/lREot4qnukO3LnPz8EPktc+8XO071PgkBP5RhCEfn7xnhEUlJl4UggrjMktcG6/Q2zjxAKCnWbaUq6rZbxkVLN/LFK98x9phLkXkNlXlIlvwwuCrWt1bMl5NRPa/kb2qEBjyVyjaTHjUpZ5LpsTfeee5PjQ8xP2eA1cN5LoEeqG1Gow7Lt0ejC01yc1ZQzAmbZ+Lmmrl08bLHYZOsj2/qAp/uCsz9NhwoFkZaEFrSZqaEHiplnqyHQbEQd1gsd4826qRsoEZIPaXV9s08JDfyrOdbnMsQ5cZHDoevD/IB83C/9YghCKhbMp+OsZpT36daBBmYr/NEPFvpYs9vpJcj8CzyFSR46nErtjA4bjj8btLmHuWcWWZX3uwISsMjCfP9++MzaiG9rPvZ70aYcdi5dsmahPrA4PsGPZcmJcpqOYASXodrDcSVTlGUGrFVWlbCpoWorZ8Fr5x+8I07m6RXkxY34QyrAziHhkZB3kpupd/JafzgPdFRgxyfKqgdz01PzNF9QRKWiAPQ+sNnWvZNgd38lVvN69y/GfpM2UYo/dm51D40r/yGPEuAWd76rvXN9uvpBhCSC9RwmsagVONOAauePZvmRxw8NCiy5z4ljQtgAzWrpuv0QfCyVzCf5i5gh1ZquRD8Q19T/iqFZkbTzSeQGcCKl3zunRi5hDT2GqdV1Dv1fr13rXieTuAnANyyra3LkHeUgg9Yyx5KOI8cUn/k74juVzogZAbq/VrjQkRKG+A83oi1FRHi0Lo+N6j2XzvRT3WJuPRdAIvrIp9ec7o8D64XjpmbbMaLT2SKPWalra4mf2wkNYTPY"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Renovate PRs for internal Side libraries are failing for repos that are using Yarn Berry. This PR is to have Renovate properly set the NPM token on the .yarnrc.yml config file which is only what Yarn Berry uses.

- Failed Renovate PR: https://github.com/reside-eng/identity-ui/pull/880#issuecomment-1420406067
- Renovate config for Yarn Berry: https://docs.renovatebot.com/getting-started/private-packages/#yarn-2