### PR TITLE
fix: set explicit range strategy

### DIFF
--- a/default.json
+++ b/default.json
@@ -7,6 +7,7 @@
     "github>reside-eng/renovate-config:private-npm",
     "github>reside-eng/renovate-config:actions-ci"
   ],
+  "rangeStrategy": "pin",
   "ignorePresets": [":prHourlyLimit2"],
   "timezone": "America/Los_Angeles",
   "prHourlyLimit": 0,

--- a/default.json
+++ b/default.json
@@ -19,6 +19,13 @@
     "extends": ["schedule:weekly"]
   },
   "packageRules": [
+     {
+      "description": "Ignore engine pinning",
+      "matchPackageNames": ["node"],
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["engines"],
+      "enabled": false
+    },
     {
       "description": "Label NPM dev dependencies",
       "matchDatasources": ["npm"],


### PR DESCRIPTION
The default range strategy is `auto` and renovate will decide on a manager-by-manager basis.
https://docs.renovatebot.com/configuration-options/#rangestrategy

~This is preventing some repos from  being pinned
example:  https://github.com/reside-eng/payment-service/blob/main/package.json#L54~
This example is no longer valid b/c I added the rangeStrategy directly to the payment-service renovate config to fix the issue in that service

I think we should force this to pin dependencies since renovate manages them anyways