### PR TITLE
fix(default): up concurrent pr limit to 20

### DIFF
--- a/default.json
+++ b/default.json
@@ -13,6 +13,7 @@
   "ignorePresets": [":prHourlyLimit2"],
   "timezone": "America/Los_Angeles",
   "prHourlyLimit": 0,
+  "prConcurrentLimit": 20,
   "platformAutomerge": true,
   "platformCommit": true,
   "lockFileMaintenance": {


### PR DESCRIPTION
:tickets: TICKET-000 <!-- Please set the ticket ID -->

<!--
## Helpful Reminders

Did you add TODO or FIXME comments?
* Create Jira tickets and add the ticket IDs to your comments

Would this code benefit from tests?
* Add tests where applicable
* Tests added using `it.todo` will be tech debt; Please create
  tickets for these (or include the tests in this PR 😄)

Did you add or modify package.json scripts?
* Update the "Local Development > Commands" section in the README

Did you add a new library?
* Consider linking to its documentation in the README
* If the library is non-trivial, consider adding a documentation
  section in the README

Did you add or modify environment variables?
* Update the "Environment Variables" section of the README

-->

## Upstream PRs

<!-- If this PR depends on other PRs, please add a bullet point list here -->

## Downstream PRs

<!-- If this PR is depended on by other PRs, please add a bullet point list here -->

## Changes
As seen [here in identity-service](https://github.com/reside-eng/identity-service/pull/1503#discussion_r1457767947) the concurrent pr limit is across all PRs, not just those created by renovate.

This PR updates the limit of concurrent PRs to 20
<!-- Describe changes made by this PR; consider using bullet points or paragraphs -->

## Notes for Reviewers

<!--
Add info that reviewers may need to know:

* Steps to try out new changes
* Known errors
* Related tasks
* Etc.

-->

## Recordings/Screenshots
![image](https://github.com/reside-eng/renovate-config/assets/2992224/95718027-e4e5-4d07-bb25-4ab94148df2e)

<!-- If this PR affects the UI, consider adding screenshots or recordings  -->
