### PR TITLE
fix: lock eslint to v8 major

### DIFF
--- a/default.json
+++ b/default.json
@@ -141,6 +141,11 @@
       "allowedVersions": "^18"
     },
     {
+      "description": "Prevent upgrade of Eslint to v9 until updates are made",
+      "matchPackageNames": ["eslint"],
+      "allowedVersions": "^8"
+    },
+    {
       "description": "Group and auto-merge minor and patch package manager, runtime (such as Nodejs, npm and yarn) dependencies on weekday mornings.",
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "matchPackageNames": ["node", "npm", "yarn"],


### PR DESCRIPTION
:tickets: TICKET-000 <!-- Please set the ticket ID -->

<!--
## Helpful Reminders

Did you add TODO or FIXME comments?
* Create Jira tickets and add the ticket IDs to your comments

Would this code benefit from tests?
* Add tests where applicable
* Tests added using `it.todo` will be tech debt; Please create
  tickets for these (or include the tests in this PR 😄)

Did you add or modify package.json scripts?
* Update the "Local Development > Commands" section in the README

Did you add a new library?
* Consider linking to its documentation in the README
* If the library is non-trivial, consider adding a documentation
  section in the README

Did you add or modify environment variables?
* Update the "Environment Variables" section of the README

-->

## Upstream PRs

<!-- If this PR depends on other PRs, please add a bullet point list here -->

## Downstream PRs

<!-- If this PR is depended on by other PRs, please add a bullet point list here -->

## Changes
Lock eslint to v8 major because v9 updates are large and will require update across our libraries
<!-- Describe changes made by this PR; consider using bullet points or paragraphs -->

## Notes for Reviewers

<!--
Add info that reviewers may need to know:

* Steps to try out new changes
* Known errors
* Related tasks
* Etc.

-->

## Recordings/Screenshots

<!-- If this PR affects the UI, consider adding screenshots or recordings  -->
