### PR TITLE
fix: group next.js updates

### DIFF
--- a/service.json
+++ b/service.json
@@ -75,6 +75,14 @@
       "matchUpdateTypes": ["patch", "minor"],
       "groupName": "MUI X",
       "updateNotScheduled": false
+    },
+    {
+      "description": "Group Next.js packages",
+      "matchPackagePrefixes": ["@next/"],
+      "matchPackageNames": ["next"],
+      "matchDepTypes": ["dependencies", "devDependencies"],
+      "groupName": "Next.js",
+      "updateNotScheduled": false
     }
   ]
 }


### PR DESCRIPTION
## Changes

This PR attempts to group all Next.js dependencies in a single PR, whether they are `dependencies` or `devDependencies`.

## Notes for Reviewers

Presently, `next` updates are separated from `@next/bundle-analyzer` and `@next/env` updates since the former is in `dependencies` and the latter two are in `devDependencies`. Vercel, however, updates `next` and `@next/env` in unison. 