### PR TITLE
feat: remove NodeJS 20 blocking rule for functions

### DIFF
--- a/functions.json
+++ b/functions.json
@@ -1,11 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>reside-eng/renovate-config:service"],
-  "packageRules": [
-    {
-      "description": "Prevent upgrade of Node above ^18 until platform updates are made (requires container + CI updates) [PLAT-6479, PLAT-6480]",
-      "matchPackageNames": ["node", "@types/node"],
-      "allowedVersions": "^18"
-    }
-  ]
+  "packageRules": []
 }


### PR DESCRIPTION
:tickets: PLAT-7554

## Upstream PRs

- https://github.com/reside-eng/identity-functions/pull/425
- https://github.com/reside-eng/platform-functions/pull/147
- https://github.com/reside-eng/payment-functions/pull/1406
- https://github.com/reside-eng/core-functions/pull/1024

## Changes

Remove blocking NodeJS 20 upgrade for functions.