### PR TITLE
fix: remove min release age exclude mui/emotion

### DIFF
--- a/default.json
+++ b/default.json
@@ -93,16 +93,10 @@
         "^@google",
         "^google-",
         "^@apollo",
-        "^@datadog",
-        "^@emoition",
-        "^@mui"
+        "^@datadog"
       ],
       "excludePackageNames": [
         "next",
-        "firebase",
-        "firebase-admin",
-        "firebase-functions",
-        "firebase-tools",
         "fastify",
         "graphql",
         "lodash",
@@ -112,7 +106,6 @@
         "recoil",
         "yup",
         "launchdarkly-react-client-sdk",
-        "pdfjs-dist",
         "pino",
         "dd-trace",
         "yarn",


### PR DESCRIPTION
:tickets: TICKET-000 <!-- Please set the ticket ID -->

<!--
## Helpful Reminders

Did you add TODO or FIXME comments?
* Create Jira tickets and add the ticket IDs to your comments

Would this code benefit from tests?
* Add tests where applicable
* Tests added using `it.todo` will be tech debt; Please create
  tickets for these (or include the tests in this PR 😄)

Did you add or modify package.json scripts?
* Update the "Local Development > Commands" section in the README

Did you add a new library?
* Consider linking to its documentation in the README
* If the library is non-trivial, consider adding a documentation
  section in the README

Did you add or modify environment variables?
* Update the "Environment Variables" section of the README

-->

## Upstream PRs

<!-- If this PR depends on other PRs, please add a bullet point list here -->

## Downstream PRs

<!-- If this PR is depended on by other PRs, please add a bullet point list here -->

## Changes
Remove MUI and emotion from `minimumReleaseAge` excludes
As discussed here in slack: https://top-agent.slack.com/archives/C02KP7ENZ52/p1718210501966779

MUI did a release which was breaking for us - because of 
<!-- Describe changes made by this PR; consider using bullet points or paragraphs -->

## Notes for Reviewers

<!--
Add info that reviewers may need to know:

* Steps to try out new changes
* Known errors
* Related tasks
* Etc.

-->

## Recordings/Screenshots

<!-- If this PR affects the UI, consider adding screenshots or recordings  -->
