### PR TITLE
fix: use correct name for yarn automerge

### DIFF
--- a/default.json
+++ b/default.json
@@ -108,7 +108,7 @@
         "launchdarkly-react-client-sdk",
         "pino",
         "dd-trace",
-        "yarn",
+        "@yarnpkg/cli",
         "npm",
         "node"
       ],

--- a/group-dep-types.json
+++ b/group-dep-types.json
@@ -60,7 +60,8 @@
     {
       "description": "Group and auto-merge minor and patch package manager, runtime (such as Nodejs, npm and yarn) dependencies on weekday mornings.",
       "matchUpdateTypes": ["minor", "patch", "digest"],
-      "matchPackageNames": ["node", "npm", "yarn"],
+      "matchPackageNames": ["node", "npm"],
+      "matchDepNames": ["yarn"],
       "schedule": ["after 5am and before 9am every weekday"],
       "automerge": true,
       "automergeType": "pr",


### PR DESCRIPTION
:tickets: TICKET-000 <!-- Please set the ticket ID -->

<!--
## Helpful Reminders

Did you add TODO or FIXME comments?
* Create Jira tickets and add the ticket IDs to your comments

Would this code benefit from tests?
* Add tests where applicable
* Tests added using `it.todo` will be tech debt; Please create
  tickets for these (or include the tests in this PR 😄)

Did you add or modify package.json scripts?
* Update the "Local Development > Commands" section in the README

Did you add a new library?
* Consider linking to its documentation in the README
* If the library is non-trivial, consider adding a documentation
  section in the README

Did you add or modify environment variables?
* Update the "Environment Variables" section of the README

-->

## Upstream PRs

<!-- If this PR depends on other PRs, please add a bullet point list here -->

## Downstream PRs

<!-- If this PR is depended on by other PRs, please add a bullet point list here -->

## Changes
Currently yarn is marked for automerge, but it is using `yarn` as the packageName (when `yarn` is actually the `depName` and `@yarnpkg/cli` is the packageName) - the correct settings (as pictured below) are:

```json
{
  "depName": "yarn",
  "packageName": "@yarnpkg/cli",
}
```
<!-- Describe changes made by this PR; consider using bullet points or paragraphs -->
[Here is an example PR in payment-service where automerge is not enabled for yarn](https://github.com/reside-eng/payment-service/pull/2817) (pictured below)

## Notes for Reviewers

<!--
Add info that reviewers may need to know:

* Steps to try out new changes
* Known errors
* Related tasks
* Etc.

-->

## Recordings/Screenshots

<!-- If this PR affects the UI, consider adding screenshots or recordings  -->
![image](https://github.com/user-attachments/assets/86ab5a55-7d8a-4a62-9b68-3d1003383084)
![image](https://github.com/user-attachments/assets/d495900c-947f-4d4c-8093-cbada41002df)
