### PR TITLE
fix: revert where using confidence score

### DIFF
--- a/default.json
+++ b/default.json
@@ -33,11 +33,35 @@
       "matchManagers": ["dockerfile"]
     },
     {
-      "description": "Require stability of NPM dependencies with low or neutral merge confidence",
+      "description": "Require stability of NPM dependencies which are not managed by Side Inc., Google or another trusted organization (since they can be unpublished)",
       "matchDatasources": ["npm"],
       "matchDepTypes": ["dependencies"],
-      "matchConfidence": ["low", "neutral"],
-      "excludePackagePatterns": ["^@side"],
+      "excludePackagePatterns": [
+        "^@side",
+        "^@google",
+        "^google-",
+        "^@apollo",
+        "^@datadog",
+        "^@fastify"
+      ],
+      "excludePackageNames": [
+        "next",
+        "fastify",
+        "fastify-plugin",
+        "graphql",
+        "lodash",
+        "date-fns",
+        "react",
+        "react-dom",
+        "recoil",
+        "yup",
+        "launchdarkly-react-client-sdk",
+        "pino",
+        "dd-trace",
+        "@yarnpkg/cli",
+        "npm",
+        "node"
+      ],
       "prCreation": "not-pending",
       "minimumReleaseAge": "3 days"
     },


### PR DESCRIPTION
### Changes

Unfortunately, using confidence score isn't supported with our current Renovate plan.