### PR TITLE
fix: node and yarn grouped separately & make other deps more lenient

### DIFF
--- a/default.json
+++ b/default.json
@@ -15,6 +15,8 @@
   "prConcurrentLimit": 30,
   "platformAutomerge": true,
   "platformCommit": "enabled",
+  "automergeType": "pr",
+  "automergeStrategy": "squash",
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,
@@ -65,6 +67,24 @@
       ],
       "prCreation": "not-pending",
       "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "Group and auto-merge non-major NodeJS dependencies on weekday mornings",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchDepNames": ["node", "@types/node"],
+      "schedule": ["after 5am and before 4pm every weekday"],
+      "groupName": "Non-major NodeJS deps",
+      "groupSlug": "non-major-nodejs-deps",
+      "automerge": true
+    },
+    {
+      "description": "Group and auto-merge non-major Yarn dependencies on weekday mornings",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchDepNames": ["yarn"],
+      "schedule": ["after 5am and before 4pm every weekday"],
+      "groupName": "Non-Major packager deps",
+      "groupSlug": "non-major-packager-deps",
+      "automerge": true
     },
     {
       "description": "Skip faker updates (since it is no longer supported)",

--- a/group-dep-types.json
+++ b/group-dep-types.json
@@ -5,7 +5,7 @@
   "automergeStrategy": "squash",
   "packageRules": [
     {
-      "description": "Automerge non-major NPM dev dependencies",
+      "description": "Auto-merge non-major NPM dev dependencies",
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "matchDatasources": ["npm"],
       "matchDepTypes": ["devDependencies"],
@@ -27,39 +27,19 @@
         "every weekend"
       ],
       "automerge": true,
-      "groupName": "Non major ci deps",
+      "groupName": "Non major CI deps",
       "groupSlug": "non-major-ci-deps",
       "updateNotScheduled": false
     },
     {
-      "description": "Group and auto-merge patch NPM dependencies on weekday mornings",
-      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "description": "Group and auto-merge non-major NPM dependencies on weekday mornings",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "matchDatasources": ["npm"],
       "matchDepTypes": ["dependencies"],
-      "schedule": ["after 5am and before 12pm every weekday"],
+      "schedule": ["after 5am and before 4pm every weekday"],
       "automerge": true,
-      "groupName": "Patch npm deps",
-      "groupSlug": "patch-npm-deps",
-      "updateNotScheduled": false
-    },
-    {
-      "description": "Group and auto-merge minor and patch package manager, runtime engine dependencies on weekday mornings",
-      "matchUpdateTypes": ["minor", "patch", "digest"],
-      "matchDepNames": ["yarn", "node", "@types/node"],
-      "schedule": ["after 5am and before 12pm every weekday"],
-      "automerge": true,
-      "groupName": "Patch packager deps",
-      "groupSlug": "patch-packager-deps",
-      "updateNotScheduled": false
-    },
-    {
-      "description": "Group minor NPM dependencies on Monday mornings",
-      "matchUpdateTypes": ["minor"],
-      "matchDatasources": ["npm"],
-      "matchDepTypes": ["dependencies"],
-      "extends": ["schedule:weekly"],
-      "groupName": "Minor npm deps",
-      "groupSlug": "minor-npm-deps",
+      "groupName": "Non-Major npm deps",
+      "groupSlug": "non-major-npm-deps",
       "updateNotScheduled": false
     }
   ]

--- a/library.json
+++ b/library.json
@@ -4,38 +4,16 @@
   "ignorePresets": [":ignoreModulesAndTests"],
   "automergeType": "pr",
   "automergeStrategy": "squash",
+  "automerge": true,
   "packageRules": [
-    {
-      "description": "Auto-merge non-major npm dev dependencies and build dependencies",
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "matchDatasources": ["npm"],
-      "matchDepTypes": ["devDependencies", "packageManager", "engines"],
-      "automerge": true
-    },
     {
       "description": "Weekly npm dependencies maintenance (grouped minor + patch updates)",
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "matchDatasources": ["npm"],
       "matchDepTypes": ["dependencies"],
-      "automerge": true,
       "extends": ["schedule:weekly"],
       "groupName": "Weekly npm maintenance release",
       "groupSlug": "weekly-npm-maintenance"
-    },
-    {
-      "description": "Group and auto-merge minor and patch package manager, runtime engine dependencies on weekday mornings",
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "matchDepNames": ["yarn", "node", "@types/node"],
-      "schedule": ["after 5am and before 9am every weekday"],
-      "automerge": true,
-      "groupName": "Patch packager deps",
-      "groupSlug": "patch-packager-deps"
-    },
-    {
-      "description": "Auto-merge non-major Github Actions dependencies",
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "matchDepTypes": ["action"],
-      "automerge": true
     },
     {
       "description": "Auto-merge examples folder non-major npm dependencies weekly on Monday morning",
@@ -45,8 +23,7 @@
       "prCreation": "not-pending",
       "extends": ["schedule:weekly"],
       "groupName": "Examples non-major",
-      "groupSlug": "examples-non-major",
-      "automerge": true
+      "groupSlug": "examples-non-major"
     },
     {
       "description": "Label examples dependencies.",
@@ -64,6 +41,11 @@
       "extends": ["schedule:weekly"],
       "groupName": "Examples major",
       "groupSlug": "examples-major"
+    },
+    {
+      "description": "Disable auto-merge for all major releases",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
### Changes

- Make libraries automerge by default but turn it off for any major release
- Split yarn and node groupings and move to default config
- Make service and UI config slightly more lenient with minor and patch deps