### PR TITLE
fix: switch prCreation back to immediate for stability deps groups

### DIFF
--- a/default.json
+++ b/default.json
@@ -65,7 +65,6 @@
         "npm",
         "node"
       ],
-      "prCreation": "not-pending",
       "minimumReleaseAge": "3 days"
     },
     {


### PR DESCRIPTION
### Changes

Remove `not-pending` from `prCreation` setting and have that default back to `immediate`. This seems to be what is blocking some of our dependency upgrades from happening as it never gets out of *Pending Status Checks*. As you can see from the screenshot below, in identity-service, there are two libs that are pending but those releases have been out for months now.
<img width="694" alt="Screenshot 2024-10-04 at 17 15 02" src="https://github.com/user-attachments/assets/0866c41e-3166-4140-9cdc-e609fc89389c">

More on the issue – https://github.com/renovatebot/renovate/discussions/21720.
