### PR TITLE
fix: adjustments to minimize CI costs responsibly

### DIFF
--- a/default.json
+++ b/default.json
@@ -17,6 +17,7 @@
   "platformCommit": "enabled",
   "automergeType": "pr",
   "automergeStrategy": "squash",
+  "rebaseWhen": "conflicted",
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,
@@ -117,6 +118,12 @@
       "description": "Prevent upgrade of Eslint to v9 until updates are made",
       "matchPackageNames": ["eslint"],
       "allowedVersions": "^8"
+    },
+    {
+      "description": "Disable auto-merge for all major releases",
+      "matchUpdateTypes": ["major"],
+      "rebaseWhen": "never",
+      "automerge": false
     }
   ]
 }

--- a/library.json
+++ b/library.json
@@ -5,6 +5,7 @@
   "automergeType": "pr",
   "automergeStrategy": "squash",
   "automerge": true,
+  "rebaseWhen": "auto",
   "packageRules": [
     {
       "description": "Weekly npm dependencies maintenance (grouped minor + patch updates)",
@@ -45,6 +46,7 @@
     {
       "description": "Disable auto-merge for all major releases",
       "matchUpdateTypes": ["major"],
+      "rebaseWhen": "never",
       "automerge": false
     }
   ]


### PR DESCRIPTION
### Changes

- By default, we will rebase when there's a CI verify conflict. Since all our services and UIs don't need to have the latest from main due to using merge queues, this will verify against main for us. Current seetings significantly increased CI minutes with rebasing "auto" by default.
- Libraries will stick with "auto" since they do not have merge queues and should be rebased. This takes less CI time as well so not a current concern. For major library releases, we set rebase to never since there will likely be conflicts.
- Move the major release check to default and ensure we do not auto-merge and rebase is set to "never" since we will likely always have conflicts and will require manual intervention regardless.