### PR TITLE
fix: group fastify deps as default, ungroup minor/patch deps

### DIFF
--- a/default.json
+++ b/default.json
@@ -13,7 +13,7 @@
   "ignorePresets": [":prHourlyLimit2"],
   "timezone": "America/Los_Angeles",
   "prHourlyLimit": 0,
-  "prConcurrentLimit": 30,
+  "prConcurrentLimit": 50,
   "platformAutomerge": true,
   "platformCommit": "enabled",
   "automergeType": "pr",
@@ -47,7 +47,8 @@
         "^google-",
         "^@apollo",
         "^@datadog",
-        "^@fastify"
+        "^@fastify",
+        "^@sinclair"
       ],
       "excludePackageNames": [
         "next",
@@ -109,6 +110,13 @@
       "matchPackagePrefixes": ["@size-limit"],
       "groupName": "Size limit packages",
       "groupSlug": "size-limit"
+    },
+    {
+      "description": "Group Fastify and Fastify scoped packages",
+      "matchPackageNames": ["fastify", "fastify-plugin"],
+      "matchPackagePrefixes": ["@fastify/"],
+      "groupName": "Fastify packages",
+      "groupSlug": "fastify-packages"
     },
     {
       "description": "Skip config updates (breaking change at 3.3.8)",

--- a/group-dep-types.json
+++ b/group-dep-types.json
@@ -38,8 +38,6 @@
       "matchDepTypes": ["dependencies"],
       "schedule": ["after 5am and before 4pm every weekday"],
       "automerge": true,
-      "groupName": "Non-Major npm deps",
-      "groupSlug": "non-major-npm-deps",
       "updateNotScheduled": false
     }
   ]

--- a/service.json
+++ b/service.json
@@ -4,13 +4,5 @@
     "github>reside-eng/renovate-config:group-dep-types",
     "github>reside-eng/renovate-config"
   ],
-  "packageRules": [
-    {
-      "description": "Group Fastify and Fastify scoped packages",
-      "matchPackageNames": ["fastify", "fastify-plugin"],
-      "matchPackagePrefixes": ["@fastify/"],
-      "groupName": "Fastify packages",
-      "groupSlug": "fastify-packages"
-    }
-  ]
+  "packageRules": []
 }


### PR DESCRIPTION
### Changes

- Group Fastify dependencies by default
- Ungroup minor and patch dependencies
- Include `@sinclair` as part of the trusted list
- Increase concurrent PR limit to 50