### PR TITLE
fix(schedule): run renovate in off hours

### DIFF
--- a/default.json
+++ b/default.json
@@ -74,7 +74,7 @@
       "description": "Group and auto-merge non-major NodeJS dependencies on weekday mornings",
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "matchDepNames": ["node", "@types/node"],
-      "schedule": ["after 5am and before 4pm every weekday"],
+      "schedule": ["before 5am and after 4pm every weekday"],
       "groupName": "Non-major NodeJS deps",
       "groupSlug": "non-major-nodejs-deps",
       "automerge": true
@@ -83,7 +83,7 @@
       "description": "Group and auto-merge non-major Yarn dependencies on weekday mornings",
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "matchDepNames": ["yarn"],
-      "schedule": ["after 5am and before 4pm every weekday"],
+      "schedule": ["before 5am and after 4pm every weekday"],
       "groupName": "Non-Major packager deps",
       "groupSlug": "non-major-packager-deps",
       "automerge": true

--- a/group-dep-types.json
+++ b/group-dep-types.json
@@ -36,7 +36,7 @@
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "matchDatasources": ["npm"],
       "matchDepTypes": ["dependencies"],
-      "schedule": ["after 5am and before 4pm every weekday"],
+      "schedule": ["before 5am and after 4pm every weekday"],
       "automerge": true,
       "updateNotScheduled": false
     }


### PR DESCRIPTION
Follow up to https://github.com/reside-eng/renovate-config/pull/76

Adjust the schedule for the new rules to run during off hours. We've got quite the merge queue going on now and it's slowing down development.

Example from txm-ui:
![Screenshot 2024-10-09 at 1 43 47 PM](https://github.com/user-attachments/assets/18de43b9-a3e7-436d-b76c-58428df35a71)
