### PR TITLE
fix: rate limit number of created PRs per hour

### DIFF
--- a/default.json
+++ b/default.json
@@ -10,9 +10,8 @@
     "github>reside-eng/renovate-config:private-npm",
     "github>reside-eng/renovate-config:actions-ci"
   ],
-  "ignorePresets": [":prHourlyLimit2"],
   "timezone": "America/Los_Angeles",
-  "prHourlyLimit": 0,
+  "prHourlyLimit": 2,
   "prConcurrentLimit": 50,
   "platformAutomerge": true,
   "platformCommit": "enabled",

--- a/default.json
+++ b/default.json
@@ -10,8 +10,9 @@
     "github>reside-eng/renovate-config:private-npm",
     "github>reside-eng/renovate-config:actions-ci"
   ],
+  "ignorePresets": [":prHourlyLimit2"],
   "timezone": "America/Los_Angeles",
-  "prHourlyLimit": 2,
+  "prHourlyLimit": 0,
   "prConcurrentLimit": 50,
   "platformAutomerge": true,
   "platformCommit": "enabled",

--- a/ui.json
+++ b/ui.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>reside-eng/renovate-config", "packages:react"],
+  "prHourlyLimit": 2,
   "packageRules": [
     {
       "description": "Group @mui/x-* packages",


### PR DESCRIPTION
We've seen an increased number of issues recently related to the a high number of renovate PRs being created at the same time and triggering the CI at the same time (mainly on Monday.
There is an interesting configuration available that gives us the ability to rate limit per hour the number of PR created by renovate for a repo (prHourlyLimit).
This one won't prevent any PR from being created according to current number/rate of created renovate PRs per repo even if the number of opened renovate PRs is multiplied by 2. We can of course refine the prHourlyLimit as our number of renovate PR increases. It will make it less brutal for our testing system, what should avoid issues we're currently seeing (e.g. okta rate limit) and other issues that could arise at scale.



:tickets: TICKET-000 <!-- Please set the ticket ID -->

<!--
## Helpful Reminders

Did you add TODO or FIXME comments?
* Create Jira tickets and add the ticket IDs to your comments

Would this code benefit from tests?
* Add tests where applicable
* Tests added using `it.todo` will be tech debt; Please create
  tickets for these (or include the tests in this PR 😄)

Did you add or modify package.json scripts?
* Update the "Local Development > Commands" section in the README

Did you add a new library?
* Consider linking to its documentation in the README
* If the library is non-trivial, consider adding a documentation
  section in the README

Did you add or modify environment variables?
* Update the "Environment Variables" section of the README

-->

## Upstream PRs

<!-- If this PR depends on other PRs, please add a bullet point list here -->

## Downstream PRs

<!-- If this PR is depended on by other PRs, please add a bullet point list here -->

## Changes

<!-- Describe changes made by this PR; consider using bullet points or paragraphs -->

## Notes for Reviewers

<!--
Add info that reviewers may need to know:

* Steps to try out new changes
* Known errors
* Related tasks
* Etc.

-->

## Recordings/Screenshots

<!-- If this PR affects the UI, consider adding screenshots or recordings  -->
