### PR TITLE
fix: do not allow libs to upgrade to React 19

### DIFF
--- a/template-library.json
+++ b/template-library.json
@@ -4,5 +4,12 @@
     "github>reside-eng/renovate-config:template-default",
     "config:js-lib"
   ],
-  "ignorePresets": [":ignoreModulesAndTests"]
+  "ignorePresets": [":ignoreModulesAndTests"],
+  "packageRules": [
+    {
+      "description": "Skip upgrade to React 19 until all applications are off of Recoil",
+      "matchPackageNames": ["react"],
+      "allowedVersions": "^18"
+    }
+  ]
 }


### PR DESCRIPTION
# Changes

Do not allow libraries to upgrade to React 19 until applications are off of Recoil.