### PR TITLE
fix: exclude memory leak dd-trace versions

### DIFF
--- a/default.json
+++ b/default.json
@@ -125,6 +125,21 @@
       "allowedVersions": "^8"
     },
     {
+      "description": "Prevent upgrade of dd-trace to v5.41.0",
+      "matchPackageNames": ["dd-trace"],
+      "allowedVersions": "!/5.41.0/"
+    },
+    {
+      "description": "Prevent upgrade of dd-trace to v5.41.1",
+      "matchPackageNames": ["dd-trace"],
+      "allowedVersions": "!/5.41.1/"
+    },
+    {
+      "description": "Prevent upgrade of dd-trace to v5.42.0",
+      "matchPackageNames": ["dd-trace"],
+      "allowedVersions": "!/5.42.0/"
+    },
+    {
       "description": "Disable auto-merge for all major releases",
       "matchUpdateTypes": ["major"],
       "rebaseWhen": "never",


### PR DESCRIPTION
Memory leak introduced in these versions, more details here: https://github.com/DataDog/dd-trace-js/issues/5389

:tickets: TICKET-000 <!-- Please set the ticket ID -->

<!--
## Helpful Reminders

Did you add TODO or FIXME comments?
* Create Jira tickets and add the ticket IDs to your comments

Would this code benefit from tests?
* Add tests where applicable
* Tests added using `it.todo` will be tech debt; Please create
  tickets for these (or include the tests in this PR 😄)

Did you add or modify package.json scripts?
* Update the "Local Development > Commands" section in the README

Did you add a new library?
* Consider linking to its documentation in the README
* If the library is non-trivial, consider adding a documentation
  section in the README

Did you add or modify environment variables?
* Update the "Environment Variables" section of the README

-->

## Upstream PRs

<!-- If this PR depends on other PRs, please add a bullet point list here -->

## Downstream PRs

<!-- If this PR is depended on by other PRs, please add a bullet point list here -->

## Changes

<!-- Describe changes made by this PR; consider using bullet points or paragraphs -->

## Notes for Reviewers

<!--
Add info that reviewers may need to know:

* Steps to try out new changes
* Known errors
* Related tasks
* Etc.

-->

## Recordings/Screenshots

<!-- If this PR affects the UI, consider adding screenshots or recordings  -->
