### PR TITLE
feat: pause next-zendesk-sdk updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -135,6 +135,11 @@
       ]
     },
     {
+      "description": "Pause @side/next-zendesk-sdk while testing refactor",
+      "matchPackageNames": ["@side/next-zendesk-sdk"],
+      "allowedVersions": "<=0.10.10"
+    },
+    {
       "description": "Disable auto-merge for all major releases",
       "matchUpdateTypes": ["major"],
       "rebaseWhen": "never",


### PR DESCRIPTION
pause next-zendesk-sdk updates while testing the refactor and new jwt flow of the lib