### PR TITLE
fix: pin axios to <=1.14.0 (1.14.1 security compromised)

### DIFF
--- a/default.json
+++ b/default.json
@@ -141,6 +141,11 @@
       ]
     },
     {
+      "description": "Prevent upgrade to axios 1.14.x (security compromised)",
+      "matchPackageNames": ["axios"],
+      "allowedVersions": "<1.14.0"
+    },
+    {
       "description": "Disable auto-merge for all major releases",
       "matchUpdateTypes": ["major"],
       "rebaseWhen": "never",

--- a/default.json
+++ b/default.json
@@ -143,7 +143,7 @@
     {
       "description": "Prevent upgrade to axios 1.14.x (security compromised)",
       "matchPackageNames": ["axios"],
-      "allowedVersions": "<1.14.0"
+      "allowedVersions": "<=1.14.0"
     },
     {
       "description": "Disable auto-merge for all major releases",


### PR DESCRIPTION
## Summary
- Pin axios to `<1.14.0` in default renovate config
- axios 1.14.1 is a security-compromised version

## Test plan
- [ ] Verify JSON is valid
- [ ] Confirm renovate applies the constraint to repos using the default preset

🤖 Generated with [Claude Code](https://claude.com/claude-code)