### PR TITLE
fix: keep GitHub Actions tag refs floating (stop Renovate pin-dependencies loop)

### DIFF
--- a/default.json
+++ b/default.json
@@ -25,6 +25,11 @@
     "extends": ["schedule:weekly"]
   },
   "packageRules": [
+    {
+      "description": "Keep GitHub Actions tag refs floating (override :pinAllExceptPeerDependencies for the github-actions manager). Renovate v43.138.0 (2026-04-21) started honouring rangeStrategy:pin for github-actions, which caused it to pin floating major tags like @v11 to specific patch tags (@v11.15.1). Combined with our auto-merge rules that accept update type 'pin', this produced an immortal auto-merged pin-dependencies PR per repo, and an infinite release loop on workflow-templates via its own self-references. SHA pinning of third-party actions is still enforced per-repo via pinDigests:true.",
+      "matchManagers": ["github-actions"],
+      "rangeStrategy": "replace"
+    },
     { "matchDatasources": ["docker"], "labels": ["docker-deps"] },
     {
       "description": "Lock redis to 6.x to match our cloud instances",


### PR DESCRIPTION
## Summary

Add a packageRule overriding `rangeStrategy: "replace"` for the `github-actions` manager, so Renovate stops rewriting floating major tag refs (`@v11`) to specific patch tags (`@v11.15.1`).

## Why

Renovate **v43.138.0** shipped on **2026-04-21** with two changes to the `github-actions` manager, both part of their work to support GitHub's Immutable Releases:

- [renovatebot/renovate#42713](https://github.com/renovatebot/renovate/pull/42713) — `feat(manager/github-actions): use github-actions versioning by default` (merged 2026-04-21 11:51:24Z)
- [renovatebot/renovate#42769](https://github.com/renovatebot/renovate/pull/42769) — `fix(versioning/github-actions): correctly handle major.minor and major` (merged 2026-04-21 11:35:36Z)

As a side effect, `rangeStrategy: "pin"` (which we inherit here via `:pinAllExceptPeerDependencies` in the `extends` list) now fires on floating tag refs. Our shared config also auto-merges the `"pin"` update type (`matchUpdateTypes: ["minor", "patch", "pin", "digest"]`), so Renovate started opening and instantly auto-merging a `fix(deps): pin dependencies` PR in **every repo** that extends this preset.

Timeline of the blast:

| Time (UTC) | Repo | PR |
|---|---|---|
| 2026-04-21 22:30:10 | `workflow-templates` | [#989](https://github.com/reside-eng/workflow-templates/pull/989) (created in Renovate v43.138.1) |
| 2026-04-21 22:33:50 | `workflow-templates-library` | #141 |
| 2026-04-22 01:08:31 | `side-next-auth` | #1518 |
| 2026-04-22 04:07–04:39 | `audit-functions`, `growth-functions`, `core-functions`, `platform-functions`, `payment-functions` | #2296, #391, #2007, #1713, #2913 |

On `workflow-templates` specifically, the repo's workflows contain self-references to older versions of itself (`reside-eng/workflow-templates/.github/actions/ci-analytics@v10`, `reside-eng/workflow-templates/.github/workflows/*@v11`, etc.). Pinning those triggered the loop:

1. Renovate pins `@v11` → `@v11.15.1`, auto-merge
2. semantic-release cuts `v11.15.2`
3. Renovate opens an "update" PR for `@v11.15.1` → `@v11.15.2`, auto-merge
4. semantic-release cuts `v11.15.3`
5. Forever — the repo hit **v11.15.376** before this was detected.

## Change

```diff
 "packageRules": [
+  {
+    "description": "Keep GitHub Actions tag refs floating (override :pinAllExceptPeerDependencies for the github-actions manager).",
+    "matchManagers": ["github-actions"],
+    "rangeStrategy": "replace"
+  },
   { "matchDatasources": ["docker"], "labels": ["docker-deps"] },
   ...
```

## What this does and doesn't affect

- **Stops** Renovate from pinning floating tag refs like `@v11` → `@v11.15.1`.
- **Does not affect** the SHA-pinning work in flight — that uses `pinDigests: true` per-repo on third-party actions only (`matchPackageNames: ["!/^reside-eng\\//"]`). `pinDigests` is a separate mechanism from `rangeStrategy` and still resolves the SHA for the tag the workflow already references.
- **Does not affect** npm `rangeStrategy: "pin"` behaviour — the override is scoped to `matchManagers: ["github-actions"]`.

## Follow-ups not in this PR

- Prune the spurious `v11.15.2` through `v11.15.376` tags + GitHub Releases on `workflow-templates` (consumers pinning `@v11` will otherwise land on them).
- Same cleanup probably warranted on `workflow-templates-library` and any other repo where the pin PR auto-merged and triggered a release.

## Test plan

- [ ] Merge and wait for Renovate's next run
- [ ] Confirm no new `fix(deps): pin dependencies` PRs are opened in repos extending this preset
- [ ] Confirm any existing open "update" PRs for workflow-templates versions stop compounding

🤖 Generated with [Claude Code](https://claude.com/claude-code)