### PR TITLE
fix: enforce 14-day minimumReleaseAge for GitHub Actions and Docker

### DIFF
--- a/default.json
+++ b/default.json
@@ -64,6 +64,17 @@
       "minimumReleaseAge": "14 days"
     },
     {
+      "description": "Require stability of GitHub Actions which are not managed by Side Inc. (since release tags can be force-moved to point at malicious code)",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["!/^reside-eng\\//"],
+      "minimumReleaseAge": "14 days"
+    },
+    {
+      "description": "Require stability of Docker images (since image tags can be re-pushed to point at malicious content)",
+      "matchDatasources": ["docker"],
+      "minimumReleaseAge": "14 days"
+    },
+    {
       "description": "Group and auto-merge non-major NodeJS dependencies on weekday mornings",
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "matchDepNames": ["node", "@types/node"],


### PR DESCRIPTION
## Summary

Extend the existing NPM release-age gate to the `github-actions` and `docker` managers.

## Why

The existing rule enforces a 14-day `minimumReleaseAge` on npm dependencies to let the community detect unpublished/withdrawn packages before we consume them. The same defence is useful for GitHub Actions and Docker images, where the attack vector is tag/digest mutation (a maintainer or attacker force-moves a release tag or image tag to point at malicious content). Waiting 14 days gives the community time to spot and report.

## Change

```diff
   "packageRules": [
     ...,
     {
       "description": "Require stability of NPM dependencies ...",
       "matchDatasources": ["npm"],
       ...
       "minimumReleaseAge": "14 days"
     },
+    {
+      "description": "Require stability of GitHub Actions which are not managed by Side Inc. (since release tags can be force-moved to point at malicious code)",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["!/^reside-eng\\//"],
+      "minimumReleaseAge": "14 days"
+    },
+    {
+      "description": "Require stability of Docker images (since image tags can be re-pushed to point at malicious content)",
+      "matchDatasources": ["docker"],
+      "minimumReleaseAge": "14 days"
+    },
```

## Scope notes

- **`reside-eng/*` GitHub Actions are excluded** so our own first-party releases (workflow-templates, reusable composite actions, etc.) are not delayed by 14 days — same philosophy as the NPM rule excluding `@side`, `@google`, `@datadog`.
- **Docker does not need an exclusion** — internal private GAR images (`us-central1-docker.pkg.dev/reside-prod`) are already disabled by the existing rule.

## Test plan

- [ ] Renovate dashboard picks up the new rule on next run
- [ ] Open update PRs for third-party actions / docker images are scheduled with at least 14 days of release age

🤖 Generated with [Claude Code](https://claude.com/claude-code)