### PR TITLE
fix(security): pin third-party GitHub Actions to immutable SHA

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -19,10 +19,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'


### PR DESCRIPTION
## Summary

Pin every third-party GitHub Action to an immutable commit SHA (with a version comment so Renovate can still manage updates). First-party reside-eng/* references are deliberately left on their floating tag.

Per GitHub security guidance, pinning to a full-length commit SHA is currently the only way to use an action as an immutable release. The trailing `# vX.Y.Z` comment is what Renovate reads to bump both the SHA and the version together on new releases.

## Pinned SHA refs

```
actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
```

## Test plan

- [ ] CI passes on this PR
