### PR TITLE
feat: centralise pinDigests + action grouping, tighten manager scope on NPM rules

### DIFF
--- a/default.json
+++ b/default.json
@@ -26,9 +26,15 @@
   },
   "packageRules": [
     {
-      "description": "Keep GitHub Actions tag refs floating (override :pinAllExceptPeerDependencies for the github-actions manager). Renovate v43.138.0 (2026-04-21) started honouring rangeStrategy:pin for github-actions, which caused it to pin floating major tags like @v11 to specific patch tags (@v11.15.1). Combined with our auto-merge rules that accept update type 'pin', this produced an immortal auto-merged pin-dependencies PR per repo, and an infinite release loop on workflow-templates via its own self-references. SHA pinning of third-party actions is still enforced per-repo via pinDigests:true.",
+      "description": "Keep GitHub Actions tag refs floating (override :pinAllExceptPeerDependencies for the github-actions manager). Renovate v43.138.0 (2026-04-21) started honouring rangeStrategy:pin for github-actions, which rewrote floating major tags like @v11 to specific patch tags (@v11.15.1). Combined with our auto-merge rules that accept update type 'pin', this produced an immortal auto-merged pin-dependencies PR per repo and an infinite release loop on workflow-templates via its own self-references. SHA pinning of third-party actions is enforced separately via the pinDigests rule below.",
       "matchManagers": ["github-actions"],
       "rangeStrategy": "replace"
+    },
+    {
+      "description": "Pin third-party GitHub Action digests (SHA + version comment). Renovate rewrites any tag-based third-party action ref to owner/repo@<sha> # vX.Y.Z so subsequent updates flow via SHA bumps. Excludes reside-eng first-party actions/workflows which stay on floating major tags (e.g. @v11) — those are managed via controlled releases.",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["!/^reside-eng\\//"],
+      "pinDigests": true
     },
     { "matchDatasources": ["docker"], "labels": ["docker-deps"] },
     {
@@ -95,6 +101,13 @@
       "automergeStrategy": "squash"
     },
     {
+      "description": "Group non-major GitHub Action updates into one PR org-wide (single group name for consistency). Auto-merge is governed by the publisher whitelist rule above. Per-category presets (group-dep-types.json for services/functions, ui.json for UIs) add a schedule on top of this grouping without re-defining the group name.",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "Non major action deps",
+      "groupSlug": "non-major-action-deps"
+    },
+    {
       "description": "Auto-merge minor/patch/digest updates for high-confidence Docker image publishers (official Docker library + trusted vendor orgs). Other images require manual review.",
       "matchDatasources": ["docker"],
       "matchUpdateTypes": ["minor", "patch", "digest"],
@@ -132,6 +145,7 @@
     },
     {
       "description": "Group and auto-merge non-major NodeJS dependencies on weekday mornings",
+      "matchManagers": ["npm"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "matchDepNames": ["node", "@types/node"],
       "schedule": ["after 5am and before 4pm every weekday"],
@@ -141,6 +155,7 @@
     },
     {
       "description": "Group and auto-merge non-major Yarn dependencies on weekday mornings",
+      "matchManagers": ["npm"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "matchDepNames": ["yarn"],
       "schedule": ["after 5am and before 4pm every weekday"],

--- a/group-dep-types.json
+++ b/group-dep-types.json
@@ -18,16 +18,14 @@
       "updateNotScheduled": false
     },
     {
-      "description": "Group non-major Github Actions dependencies (auto-merge governed by the shared publisher whitelist in default.json)",
+      "description": "Schedule non-major GitHub Action updates for weekday evenings + weekends. Grouping and auto-merge are defined centrally in default.json.",
+      "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "matchDepTypes": ["action"],
       "schedule": [
         "after 8pm every weekday",
         "before 8am every weekday",
         "every weekend"
       ],
-      "groupName": "Non major CI deps",
-      "groupSlug": "non-major-ci-deps",
       "updateNotScheduled": false
     },
     {

--- a/ui.json
+++ b/ui.json
@@ -21,12 +21,10 @@
       "updateNotScheduled": false
     },
     {
-      "description": "Group non-major Github Actions dependencies (auto-merge governed by the shared publisher whitelist in default.json)",
+      "description": "Schedule non-major GitHub Action updates for Monday mornings. Grouping and auto-merge are defined centrally in default.json.",
+      "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "matchDepTypes": ["action"],
       "schedule": ["after 9am on monday"],
-      "groupName": "Non major CI deps",
-      "groupSlug": "non-major-ci-deps",
       "updateNotScheduled": false
     },
     {


### PR DESCRIPTION
## Summary

Consolidation follow-up to #117. Three sets of rules that were duplicated across ~12 per-repo `renovate.json` files, or scattered across multiple shared presets with inconsistent group names, are now centralised in `default.json`. The matching per-repo rules have already been removed on their respective SHA-pin / PR A branches, so this PR is the "receiving end" — once merged, every repo that extends this preset automatically gets the consolidated behaviour, with no per-repo duplication.

## Changes

### `default.json`

#### 1. New rule — SHA-pin all third-party GitHub Action refs

```json
{
  "description": "Pin third-party GitHub Action digests (SHA + version comment)...",
  "matchManagers": ["github-actions"],
  "matchPackageNames": ["!/^reside-eng\\//"],
  "pinDigests": true
}
```

Previously maintained inline in ~12 repos (ci/workflow-templates*, terraforms/*, devops/*, github-actions/*). Moving to shared means:
- Every repo extending `reside-eng/renovate-config` now gets pin-enforcement by default, including the ~30+ repos we never manually SHA-pinned.
- First-party `reside-eng/*` actions continue to use floating major tags (e.g. `@v11`) — explicitly excluded.

#### 2. New rule — single org-wide action grouping

```json
{
  "description": "Group non-major GitHub Action updates into one PR org-wide (single group name for consistency)...",
  "matchManagers": ["github-actions"],
  "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
  "groupName": "Non major action deps",
  "groupSlug": "non-major-action-deps"
}
```

Before this PR, three different group names were in use across the org (`Non major CI deps`, `Non major deps`, `Non major action deps`). Now everything uses one: `Non major action deps` / `non-major-action-deps`.

Auto-merge still controlled by the publisher whitelist added in #117 — this rule only affects grouping, not the automerge decision.

#### 3. Tighten `matchManagers: ["npm"]` on existing NodeJS + Yarn rules

The `Group and auto-merge non-major NodeJS dependencies on weekday mornings` and the equivalent Yarn rule used only `matchDepNames: ["node", "@types/node"]` / `["yarn"]`. A Docker image literally named `node` would technically match (same depName). Current behaviour is unchanged because the Docker whitelist also auto-merges `node`, but adding the manager filter documents intent and prevents accidental cross-manager collisions in future rule changes.

### `group-dep-types.json` (inherited by service/functions)

The previous action rule duplicated `groupName`/`groupSlug` and the schedule. Narrowed to schedule-only:

```json
{
  "description": "Schedule non-major GitHub Action updates for weekday evenings + weekends. Grouping and auto-merge are defined centrally in default.json.",
  "matchManagers": ["github-actions"],
  "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
  "schedule": ["after 8pm every weekday", "before 8am every weekday", "every weekend"],
  "updateNotScheduled": false
}
```

Grouping (now `"Non major action deps"`) and auto-merge (whitelist) flow from `default.json`; the schedule is what's unique to services/functions and stays here.

### `ui.json` (inherited by UIs)

Same pattern — narrowed to schedule-only (Monday mornings).

## Rule-evaluation order (sanity check)

For a service/functions repo (extends `service.json` → `group-dep-types.json` + `default.json`), for an action update:
1. `group-dep-types.json` sets the schedule.
2. `default.json` sets the groupName/groupSlug (via the new grouping rule), pinDigests, and auto-merge (via the whitelist).
3. Per-repo rules apply last (if any).

Net result: scheduled PR with consistent name, SHA-pinned, auto-merged only if the publisher is whitelisted. Same logic for UIs, with the Monday schedule from `ui.json`.

## Related PRs (merge after this lands)

- All the open SHA-pin PRs — their feat branches already have commits removing the inline `pinDigests` and `"Non major deps"` / `"Non major action deps"` rules so there's no duplication once this lands.
- `reside-eng/workflow-templates#1373` — same cleanup committed on top of the PR A standalone for workflow-templates.

## Transition notes

- **Brief window**: if this PR lands *before* the SHA-pin wave is fully merged, there's a short stretch where some repos have unpinned third-party actions on `main`. Renovate will open `fix(deps): pin dependencies` PRs for those. The `rangeStrategy: "replace"` scoped to github-actions (already merged in #115) prevents the v11 → v11.15.x cascade; the 14-day `minimumReleaseAge` throttles the pin PR wave. Should be fine but worth noting.
- **Group name change**: repos whose previous inline grouping used `"Non major deps"` (CI templates, devops-toolshed) or `"Non major action deps"` (terraform) will transition to the shared `"Non major action deps"` name. Repos using `"Non major CI deps"` (services/functions/UIs via presets) also transition. Renovate handles group-name changes by closing the old grouped PR and opening a new one under the new slug — one-off churn, nothing persistent.

## Test plan

- [ ] Merge after the SHA-pin wave has landed (so nothing is unpinned on main)
- [ ] Verify no spurious `fix(deps): pin dependencies` PR wave opens (if it does, 14-day age + rangeStrategy:replace still provide coverage)
- [ ] Confirm a whitelisted action update (e.g. `actions/checkout` patch) still auto-merges
- [ ] Confirm a non-whitelisted action update (e.g. `tibdex/*`) creates a PR but does not auto-merge
- [ ] Spot-check a service repo: action PR is grouped as `Non major action deps` with the schedule from `group-dep-types.json`
- [ ] Spot-check a UI repo: action PR is grouped as `Non major action deps` with the Monday schedule from `ui.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
