### PR TITLE
fix: treat pre-1.0 minor bumps as breaking

### DIFF
--- a/default.json
+++ b/default.json
@@ -228,6 +228,13 @@
       "matchUpdateTypes": ["major"],
       "rebaseWhen": "never",
       "automerge": false
+    },
+    {
+      "description": "Treat pre-1.0 minor bumps as breaking. Per semver convention (and npm caret semantics, where ^0.9.6 resolves to >=0.9.6 <0.10.0), a 0.x → 0.(x+1) bump is a breaking change. Renovate classifies these as 'minor' by default, so without this rule they bypass the major-release automerge guard.",
+      "matchCurrentVersion": "/^0\\./",
+      "matchUpdateTypes": ["minor"],
+      "rebaseWhen": "never",
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Renovate classifies `0.9.x → 0.10.x` as a `minor` update by default, so it bypasses the existing **Disable auto-merge for all major releases** rule and gets squash-merged automatically.
- Per semver convention — and npm caret semantics, where `^0.9.6` resolves to `>=0.9.6 <0.10.0` — a `0.x → 0.(x+1)` bump is a breaking change and should require manual review.
- Recently triggered by `@side/pubsub` `0.9.6 → 0.10.0` auto-merging into a consuming service. The same trap explains the existing `allowedVersions` blocklist for `@side/fastify-identity-auth@2.0.20` and `@side/identity-token@5.1.24` — internal libs accidentally publishing breaking changes that Renovate didn't classify as major.

## Change
Adds a packageRule next to the existing major guard:

```json
{
  "matchCurrentVersion": "/^0\\./",
  "matchUpdateTypes": ["minor"],
  "rebaseWhen": "never",
  "automerge": false
}
```

Applied org-wide via `default.json` so it covers services, UIs, libraries, and functions.

## Test plan
- [ ] Renovate dry-run / dashboard shows automerge disabled on the next 0.x minor bump (e.g. an `@side/*` 0.x lib).
- [ ] Confirm 1.x+ minor bumps still automerge (regression check on next routine npm-deps PR).
- [ ] Confirm 0.x patch bumps (e.g. `0.9.6 → 0.9.7`) still automerge.