### PR TITLE
fix: lock node version to 24.15 due to memory like in 24.16

### DIFF
--- a/service.json
+++ b/service.json
@@ -4,5 +4,12 @@
     "github>reside-eng/renovate-config:group-dep-types",
     "github>reside-eng/renovate-config"
   ],
-  "packageRules": []
+  "packageRules": [
+    {
+      "description": "Pin node Docker image to 24.15.0 — 24.16.0 has a memory leak",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["node"],
+      "allowedVersions": "24.15.0"
+    }
+  ]
 }

--- a/ui.json
+++ b/ui.json
@@ -42,6 +42,12 @@
       "matchDatasources": ["npm"],
       "matchPackageNames": ["@apollo/client"],
       "allowedVersions": "3.x"
+    },
+    {
+      "description": "Pin node Docker image to 24.15.0 — 24.16.0 has a memory leak",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["node"],
+      "allowedVersions": "24.15.0"
     }
   ]
 }


### PR DESCRIPTION
:tickets: TICKET-000 <!-- Please set the ticket ID -->

<!--
## Helpful Reminders

Did you add TODO or FIXME comments?
* Create Jira tickets and add the ticket IDs to your comments

Would this code benefit from tests?
* Add tests where applicable
* Tests added using `it.todo` will be tech debt; Please create
  tickets for these (or include the tests in this PR 😄)

Did you add or modify package.json scripts?
* Update the "Local Development > Commands" section in the README

Did you add a new library?
* Consider linking to its documentation in the README
* If the library is non-trivial, consider adding a documentation
  section in the README

Did you add or modify environment variables?
* Update the "Environment Variables" section of the README

-->

## Upstream PRs

<!-- If this PR depends on other PRs, please add a bullet point list here -->

## Downstream PRs

<!-- If this PR is depended on by other PRs, please add a bullet point list here -->

## Changes
Lock docker node version to 24.15 since 24.16 has a memory leak

[The support thread in slack](https://top-agent.slack.com/archives/CTA1YT5T8/p1780687104486949)
[The eng-org clarification of the issue](https://top-agent.slack.com/archives/CP7UW4VHT/p1780693045220959)

<!-- Describe changes made by this PR; consider using bullet points or paragraphs -->

## Notes for Reviewers

<!--
Add info that reviewers may need to know:

* Steps to try out new changes
* Known errors
* Related tasks
* Etc.

-->

## Recordings/Screenshots

<!-- If this PR affects the UI, consider adding screenshots or recordings  -->
