### PR TITLE
fix(deps): treat node docker image bumps as fix, not chore

### DIFF
--- a/default.json
+++ b/default.json
@@ -38,6 +38,12 @@
     },
     { "matchDatasources": ["docker"], "labels": ["docker-deps"] },
     {
+      "description": "Treat Node runtime image bumps as real deps (fix), not chore. The dockerfile manager's node FROM updates fall through to chore via :semanticPrefixFixDepsChoreOthers (only npm/maven/python prod depTypes get fix); a runtime version change can affect the app, so override to fix.",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["node"],
+      "semanticCommitType": "fix"
+    },
+    {
       "description": "Lock redis to 6.x to match our cloud instances",
       "matchDatasources": ["docker"],
       "matchPackageNames": ["redis"],


### PR DESCRIPTION
## Problem

Node base-image bumps (`FROM node:X` in Dockerfiles) have been landing as `chore(deps): update node docker tag …` instead of `fix`. A Node runtime version change can have real impact on our apps, so it should be classified as a real dependency update (`fix`), not a dev-dependency-style `chore`.

## Root cause

`fix` vs `chore` is decided by the `:semanticPrefixFixDepsChoreOthers` preset (inherited via `config:recommended`). It defaults **everything** to `chore` and only flips to `fix` for npm `dependencies`/`require` and a few Maven/Python production depTypes. Node image bumps come through Renovate's **dockerfile manager** (datasource `docker`, depType `final`/`stage`) — none of which are on the `fix` list — so they fall through to `chore`. It was never classified as a dev-dep; it just never qualified for `fix`.

## Fix

One `packageRule` added to `default.json` — the shared base preset every category (`service`/`ui`/`functions`/`library`) extends, so it applies org-wide:

```json
{
  "matchDatasources": ["docker"],
  "matchPackageNames": ["node"],
  "semanticCommitType": "fix"
}
```

It sits in our own `packageRules` (which run after the `extends` presets), so it correctly overrides the preset per the "later rules win" ordering. Scoped to the `node` package on the `docker` datasource → consistent across all `FROM` stages, while leaving local dev/test images (postgres, redis, pubsub emulator in docker-compose) as `chore`.

## Behavioral impact

Node image bumps will now emit `fix(deps): …`. For services/UIs on semantic-release that means each one auto-merges **and** cuts a patch release/deploy (previously silent `chore` with no release). This is the intended "treat it as a real dep" outcome — flagging the increased deploy volume so it's expected.

## Validation

`renovate-config-validator --strict default.json` passes with no errors. (The pre-existing "config migration" warning relates to deprecated fields elsewhere in the file, not this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)